### PR TITLE
Fixed bad calculation of total consumed time on contract day from child entities on parent contract

### DIFF
--- a/inc/cridetail.class.php
+++ b/inc/cridetail.class.php
@@ -624,8 +624,7 @@ class PluginManageentitiesCriDetail extends CommonDBTM {
                      ON (`glpi_plugin_manageentities_cridetails`.`tickets_id` = `glpi_tickets`.`id`)"
                         . " LEFT JOIN `glpi_tickettasks` 
                      ON (`glpi_tickettasks`.`tickets_id` = `glpi_tickets`.`id`)"
-                        . " WHERE `glpi_plugin_manageentities_cridetails`.`contracts_id` = '" . $contractDayValues["contracts_id"] . "' 
-                 AND `glpi_plugin_manageentities_cridetails`.`entities_id` = '" . $contractDayValues["entities_id"] . "' 
+                        . " WHERE `glpi_plugin_manageentities_cridetails`.`contracts_id` = '" . $contractDayValues["contracts_id"] . "'
                  AND `glpi_plugin_manageentities_cridetails`.`plugin_manageentities_contractdays_id` = '" . $contractDayValues["contractdays_id"] . "' 
                  AND `glpi_tickets`.`is_deleted` = 0
                  AND `glpi_tickettasks`.`actiontime` > 0";


### PR DESCRIPTION
In the function that calculate total consumed time on a contract day, the informations gathered are limited to the entity owning the contract day, but it's possible to link child entities to parent contract so that they can access contract days of parent entity.

So I just removed entity restriction in SQL query, where it's not needed as conditions are made on multiple ID which are unique so it does causes any problem to remove the entity condition.

It fixes issue #13 